### PR TITLE
Release v0.2.0

### DIFF
--- a/falcon_boilerplate/__init__.py
+++ b/falcon_boilerplate/__init__.py
@@ -1,19 +1,1 @@
-import falcon_sqla
-
 __version__ = "0.2.0"
-
-_sqla_manager: falcon_sqla.Manager = None
-
-
-class _SqlaManager:
-    @property
-    def manager(self):
-        return _sqla_manager
-
-    @manager.setter
-    def manager(self, manager):
-        global _sqla_manager
-        _sqla_manager = manager
-
-
-sqla_manager = _SqlaManager()

--- a/falcon_boilerplate/__init__.py
+++ b/falcon_boilerplate/__init__.py
@@ -1,6 +1,6 @@
 import falcon_sqla
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 _sqla_manager: falcon_sqla.Manager = None
 

--- a/falcon_boilerplate/controller.py
+++ b/falcon_boilerplate/controller.py
@@ -13,7 +13,7 @@ from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import DeclarativeMeta, Query
 from sqlalchemy.orm.collections import InstrumentedList
 
-from falcon_boilerplate import sqla_manager
+from falcon_boilerplate.sqlaman import sqla_manager
 from falcon_boilerplate.exceptions import SqlaManagerRequired
 from falcon_boilerplate.strfunc import camel_case_to_snake_case
 

--- a/falcon_boilerplate/router/controller.py
+++ b/falcon_boilerplate/router/controller.py
@@ -57,10 +57,10 @@ class ControllerRouter(BaseRouter):
         try:
             if pk is not None:
                 record = self.controller.read_single(pk=pk)
-                res.text = json.dumps(record)
+                res.text = self.json(record)
             else:
                 records = self.controller.read_list()
-                res.text = json.dumps(records)
+                res.text = self.json(records)
             return
         except (HTTPMethodNotAllowed, HTTPNotFound) as _err:
             raise _err

--- a/falcon_boilerplate/sqlaman.py
+++ b/falcon_boilerplate/sqlaman.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+import falcon_sqla
+
+_sqla_manager: Union[falcon_sqla.Manager, None] = None
+
+
+class _SqlaManager:
+    @property
+    def manager(self):
+        return _sqla_manager
+
+    @manager.setter
+    def manager(self, manager):
+        global _sqla_manager
+        _sqla_manager = manager
+
+
+sqla_manager = _SqlaManager()


### PR DESCRIPTION
# What's changed
- Added ability in controller to add custom query filters
- Updated router.BaseRouter.json() method, making camel cased identifiers in output optional and configurable. This also removed camel casing indentifiers inside controller
- Updated router.ControllerRouter to use router.BaseRouter.json() when returning output, instead of using json.dumps() directly
- Removed somewhat custom filtering for 'deleted_at' in controller, since this can/should be achieved using custom query filters
- The introduction of query filter and the added exception handling wasn't working properly, this fixes some issues found
- Moved sqlalchemy manager to own file